### PR TITLE
Add growl gem for Mac environment only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ group :development do
   gem 'guard-minitest'
   gem 'guard-livereload'
   gem 'rack-livereload'
-  gem 'libnotify'
   gem 'better_errors'
   gem 'binding_of_caller', platforms: :mri_21
   gem 'quiet_assets'
@@ -39,7 +38,14 @@ group :development do
   gem 'rails_layout'
   gem 'rails_best_practices'
   gem 'rails_apps_pages'
+  group :linux do
+    gem 'libnotify', require: false
+  end
+  group :darwin do
+    gem 'growl', require: false
+  end
 end
+
 gem 'minitest-rails'
 group :test do
   gem 'minitest-reporters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     formatador (0.2.5)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    growl (1.0.3)
     guard (2.13.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -339,6 +340,7 @@ DEPENDENCIES
   devise
   faker
   font-awesome-sass
+  growl
   guard-bundler
   guard-livereload
   guard-minitest


### PR DESCRIPTION
Add libnotify for Linux environment only.

The changes enables the development under Linux and Mac.
